### PR TITLE
Reset form when item is updated

### DIFF
--- a/src/components/ItemsListItem.tsx
+++ b/src/components/ItemsListItem.tsx
@@ -27,18 +27,28 @@ const ItemsListItem: React.FC<ItemsListItemProps> = ({
   const {
     register: registerQuantity,
     handleSubmit: handleSubmitQuantity,
+    reset: quantityReset,
     errors: quantityErrors,
   } = useForm<QuantityFormData>({
     defaultValues: { quantity: item.quantity.toString() },
   });
 
+  useEffect(() => {
+    quantityReset({ quantity: item.quantity.toString() });
+  }, [quantityReset, item.quantity]);
+
   const {
     register: registerName,
     handleSubmit: handleSubmitName,
+    reset: resetName,
     errors: nameErrors,
   } = useForm<NameFormData>({
     defaultValues: { name: item.name },
   });
+
+  useEffect(() => {
+    resetName({ name: item.name });
+  }, [resetName, item.name]);
 
   const onSubmitQuantity = ({ quantity }: QuantityFormData) => {
     update({ ...item, quantity: parseFloat(quantity) });


### PR DESCRIPTION
Fixes a slight bug: when the item was updated, the form would still use default values from when it was first created (they're cached by `react-hook-form`).

As a side note, it may be worth looking into reducing the duplication between the two forms (just make them a single form/factor out a component?)