### PR TITLE
Reverse the items when copied to clipboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -355,6 +355,7 @@ const App: React.FC = () => {
       .flat()
       .map((iId) => shoppingList.items[iId])
       .map((i) => `${i.quantity} ${i.name}`)
+      .reverse()
       .join("\n");
 
   const onCopyToClipboard = () => {


### PR DESCRIPTION
This is so when they are then pasted into e.g Microsoft todo, they will then be in the correct order